### PR TITLE
Update story_list() to handle indexed_date values with or without microseconds

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -1,6 +1,5 @@
 import datetime as dt
 import logging
-from multiprocessing.sharedctypes import Value
 from typing import Any, Dict, List, Optional, Union
 
 import requests

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -156,13 +156,7 @@ class SearchApi(BaseApi):
         results = self._query('search/story-list', params)
         for s in results['stories']:
             s['publish_date'] = dt.date.fromisoformat(s['publish_date'][:10]) if s['publish_date'] else None
-            try:
-                s['indexed_date'] = dt.datetime.strptime(s['indexed_date'], '%Y-%m-%d %H:%M:%S.%f')\
-                    if s['indexed_date'] else None
-            # If indexed_date does not fit the %S.%f format, it will generate a ValueError
-            except ValueError:
-                s['indexed_date'] = dt.datetime.strptime(s['indexed_date'], '%Y-%m-%d %H:%M:%S')\
-                    if s['indexed_date'] else None
+            s['indexed_date'] = dt.datetime.fromisoformat(s['indexed_date']) if s['indexed_date'] else None
         return results['stories'], results['pagination_token']
 
     def story(self, story_id: str) -> Dict:


### PR DESCRIPTION
In reference to #88, this PR sets up a try/except block to include the maximum available resolution of a given timestamp in indexed_date rather than truncating data that comes after the seconds.