### PR TITLE
remove sort_field option and related tests in story_list

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -115,7 +115,7 @@ class SearchApi(BaseApi):
                              collection_ids: Optional[List[int]] = [], source_ids: Optional[List[int]] = [],
                              platform: Optional[str] = None):
         params: Dict[Any, Any] = dict(start=start_date.isoformat(), end=end_date.isoformat(), q=query,
-                                      platform=self.PROVIDER)
+                                      platform=(platform or self.PROVIDER))
         if len(source_ids):
             params['ss'] = ",".join([str(sid) for sid in source_ids]),
         if len(collection_ids):
@@ -140,15 +140,13 @@ class SearchApi(BaseApi):
     def story_list(self, query: str, start_date: dt.date, end_date: dt.date, collection_ids: Optional[List[int]] = [],
                    source_ids: Optional[List[int]] = [], platform: Optional[str] = None,
                    expanded: Optional[bool] = None, pagination_token: Optional[str] = None,
-                   sort_field: Optional[str] = None, sort_order: Optional[str] = None,
+                   sort_order: Optional[str] = None,
                    page_size: Optional[int] = None) -> tuple[List[Dict], Optional[str]]:
         params = self._prep_default_params(query, start_date, end_date, collection_ids, source_ids, platform)
         if expanded:
             params['expanded'] = 1
         if pagination_token:
             params['pagination_token'] = pagination_token
-        if sort_field:
-            params['sort_field'] = sort_field
         if sort_order:
             params['sort_order'] = sort_order
         if page_size:

--- a/mediacloud/test/api_search_test.py
+++ b/mediacloud/test/api_search_test.py
@@ -6,7 +6,6 @@ import mediacloud.api
 
 COLLECTION_US_NATIONAL = 34412234
 AU_BROADCAST_COMPANY = 20775
-TOMORROW = dt.date.today() + dt.timedelta(days=1)
 TOMORROW_TIME = dt.datetime.today() + dt.timedelta(days=1)
 
 
@@ -118,37 +117,19 @@ class DirectoryTest(TestCase):
         # desc
         page, _ = self._search.story_list(query="weather", start_date=self.START_DATE, end_date=self.END_DATE,
                                           collection_ids=[COLLECTION_US_NATIONAL])
-        last_pub_date = TOMORROW
-        for story in page:
-            assert 'publish_date' in story
-            assert story['publish_date'] <= last_pub_date
-            last_pub_date = story['publish_date']
-        # asc
-        page, _ = self._search.story_list(query="weather", start_date=self.START_DATE, end_date=self.END_DATE,
-                                          collection_ids=[COLLECTION_US_NATIONAL], sort_order='asc')
-        a_long_time_ago = dt.date(2000, 1, 1)
-        last_pub_date = a_long_time_ago
-        for story in page:
-            assert 'publish_date' in story
-            assert story['publish_date'] >= last_pub_date
-            last_pub_date = story['publish_date']
-
-    def test_story_list_sort_field(self):
-        # publish_date
-        page, _ = self._search.story_list(query="weather", start_date=self.START_DATE, end_date=self.END_DATE,
-                                          collection_ids=[COLLECTION_US_NATIONAL])
-        last_date = TOMORROW
-        for story in page:
-            assert 'publish_date' in story
-            assert story['publish_date'] <= last_date
-            last_date = story['publish_date']
-        # indexed date
-        page, _ = self._search.story_list(query="weather", start_date=self.START_DATE, end_date=self.END_DATE,
-                                          collection_ids=[COLLECTION_US_NATIONAL], sort_field="indexed_date")
         last_date = TOMORROW_TIME
         for story in page:
             assert 'indexed_date' in story
             assert story['indexed_date'] <= last_date
+            last_date = story['indexed_date']
+        # asc
+        page, _ = self._search.story_list(query="weather", start_date=self.START_DATE, end_date=self.END_DATE,
+                                          collection_ids=[COLLECTION_US_NATIONAL], sort_order='asc')
+        a_long_time_ago = dt.datetime(2000, 1, 1, 0, 0, 0)
+        last_date = a_long_time_ago
+        for story in page:
+            assert 'indexed_date' in story
+            assert story['indexed_date'] >= last_date
             last_date = story['indexed_date']
 
     def test_search_by_indexed_date(self):


### PR DESCRIPTION
Now that we're seeing `indexed_date` as the proper sort order for paging through lists of stories, we should remove the option for other things, and associated tests. This fixes some unit tests by making that change in the code.