### PR TITLE
Added more detailed results to the feed_list query

### DIFF
--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -94,7 +94,7 @@ class DirectoryApi(BaseApi):
     def feed_list(self, source_id: Optional[int] = None,
                   modified_since: Optional[Union[dt.datetime, int, float]] = None,
                   modified_before: Optional[Union[dt.datetime, int, float]] = None,
-                  limit: Optional[int] = 0, offset: Optional[int] = 0, return_details=False) -> Dict:
+                  limit: Optional[int] = 0, offset: Optional[int] = 0, return_details: bool =False) -> Dict:
         params: Dict[Any, Any] = dict(limit=limit, offset=offset)
         if source_id:
             params['source_id'] = source_id

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -94,7 +94,7 @@ class DirectoryApi(BaseApi):
     def feed_list(self, source_id: Optional[int] = None,
                   modified_since: Optional[Union[dt.datetime, int, float]] = None,
                   modified_before: Optional[Union[dt.datetime, int, float]] = None,
-                  limit: Optional[int] = 0, offset: Optional[int] = 0, return_details: bool =False) -> Dict:
+                  limit: Optional[int] = 0, offset: Optional[int] = 0, return_details: bool = False) -> Dict:
         params: Dict[Any, Any] = dict(limit=limit, offset=offset)
         if source_id:
             params['source_id'] = source_id

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -94,7 +94,7 @@ class DirectoryApi(BaseApi):
     def feed_list(self, source_id: Optional[int] = None,
                   modified_since: Optional[Union[dt.datetime, int, float]] = None,
                   modified_before: Optional[Union[dt.datetime, int, float]] = None,
-                  limit: Optional[int] = 0, offset: Optional[int] = 0) -> Dict:
+                  limit: Optional[int] = 0, offset: Optional[int] = 0, return_details=False) -> Dict:
         params: Dict[Any, Any] = dict(limit=limit, offset=offset)
         if source_id:
             params['source_id'] = source_id
@@ -111,7 +111,10 @@ class DirectoryApi(BaseApi):
 
         epoch_param(modified_since, 'modified_since')
         epoch_param(modified_before, 'modified_before')
-
+        
+        if return_details:
+            return self._query('sources/feeds/details/', params)
+        
         return self._query('sources/feeds/', params)
 
 

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -113,7 +113,7 @@ class DirectoryApi(BaseApi):
         epoch_param(modified_before, 'modified_before')
         
         if return_details:
-            return self._query('sources/feeds/details/', params)
+            return {'results':self._query('sources/feeds/details/', params)['feeds']}
         
         return self._query('sources/feeds/', params)
 

--- a/mediacloud/api.py
+++ b/mediacloud/api.py
@@ -68,12 +68,14 @@ class DirectoryApi(BaseApi):
         return self._query(f'sources/collections/{collection_id}/', None)
 
     def collection_list(self, platform: Optional[str] = None, name: Optional[str] = None,
-                        limit: Optional[int] = 0, offset: Optional[int] = 0) -> Dict:
+                        limit: Optional[int] = 0, offset: Optional[int] = 0, source_id: Optional[int] = None) -> Dict:
         params: Dict[Any, Any] = dict(limit=limit, offset=offset)
         if name:
             params['name'] = name
         if platform:
             params['platform'] = platform
+        if source_id:
+            params['source_id'] = source_id
         return self._query('sources/collections/', params)
 
     def source(self, source_id:int):


### PR DESCRIPTION
for some reason, the api service gives both a 'feeds' and 'feed_details' endpoint to iterate through source feeds- most of the useful information is contained in the latter. I'm tempted to just replace one with the other- I doubt that there are any consumers of this endpoint outside of the org- but for now I've just made a switch so you can optionally get more detail while leaving the previous behavior as a default. 