### PR TITLE
fix automated release issue

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,8 @@
 name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
 
-on: 
+on:
   push:
-    tags: 
+    tags:
       - "*"
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.6.2
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Right now we can't do automated releases, because of the error described in #105 . The suggested fix is to upgrade to `actions/upload-artifact@v4.6.2`. Curious that the bot didn't suggest this alongside the fix for download-artifact (#93).

I gave the migration guide and it doesn't look like any of the breaking changes impact our usage, but this definitely needs another pair of eyes reading to verify: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

Also is there any way to test this automation against just the test deploy server? Or do we have to just push a real tag and have it build a real release?